### PR TITLE
Changes to navigationBar - Revisiting #662

### DIFF
--- a/components/navigationBar/index.html
+++ b/components/navigationBar/index.html
@@ -1,11 +1,14 @@
-<button v-if="back === true" class="back nav-btn" v-on="click: goBack">&lt;</button>
-<a v-if="typeof back === 'string'" class="back nav-btn" href="{{back}}">&lt;</a>
+<div>
+    <button v-if="back === true" class="back nav-btn" v-on="click: goBack">&lt;</button>
+    <a v-if="typeof back === 'string'" class="back nav-btn" href="{{back}}">&lt;</a>
 
-<button v-if="cancel === true" v-on="click: goBack" class="nav-btn">{{'Cancel' | i18n}}</button>
-<a v-if="typeof cancel === 'string'" href="{{cancel}}" class="nav-btn">{{'Cancel' | i18n}}</a>
+    <button v-if="cancel === true" v-on="click: goBack" class="nav-btn">{{'Cancel' | i18n}}</button>
+    <a v-if="typeof cancel === 'string'" href="{{cancel}}" class="nav-btn">{{'Cancel' | i18n}}</a>
+</div>
 
 <h1>{{title | i18n}}</h1>
 
-<button v-if="typeof onDone === 'function'" v-on="click: onDone" v-class="disabled: doneDisabled" class="nav-btn">{{doneLabel || 'Done' | i18n}}
-</button>
-<a v-show="!offlineUser" v-if="typeof onDone === 'string'" href="{{onDone}}" v-class="disabled: doneDisabled" class="nav-btn">{{doneLabel || 'Done' | i18n}}</a>
+<div>
+    <button v-if="typeof onDone === 'function'" v-on="click: onDone" v-class="disabled: doneDisabled" class="nav-btn">{{doneLabel || 'Done' | i18n}}</button>
+    <a v-show="!offlineUser" v-if="typeof onDone === 'string'" href="{{onDone}}" v-class="disabled: doneDisabled" class="nav-btn">{{doneLabel || 'Done' | i18n}}</a>
+</div>

--- a/components/navigationBar/index.less
+++ b/components/navigationBar/index.less
@@ -4,21 +4,25 @@
     left: 0;
     top: 0;
     z-index: 2;
-
     width: 100%;
     height: @header-height;
-    border-bottom: 1px solid @lightGrey;
-    background-color: @white;
-    text-align: center;
 
+    display: flex;
+    align-items: center;
+
+    & > div {
+        flex: 1;
+    }
+    & > div:nth-child(3) {
+        text-align: right;
+    }
+
+    // Flex property not needed in h1
     h1 {
-        display: inline-block;
-        margin: 13px auto 0 auto;
         color: @highlight;
         text-align: center;
         font-size: 1.1em;
         font-weight: 400;
-        width: 100%;
     }
 
     a {
@@ -49,15 +53,11 @@
     }
 
     .nav-btn {
-        position: absolute;
-        top: 0;
-        min-width: 40px;
-        height: 100%;
         background: none;
         color: @highlight;
         border: none;
         outline: none;
-        padding: 5px 20px 0;
+        padding: 0px 20px 0;
         line-height: (@header-height - 10s);
         text-decoration: none;
         font-size: 13px;
@@ -65,7 +65,6 @@
             font-size: inherit;
             padding-top: 0;
         }
-
         &:first-child {
             left: 0;
         }
@@ -74,10 +73,29 @@
         }
         &.back {
             line-height: @header-height;
-            padding-top: 0;
             font-size: 1.4em;
         }
+    }
 
+    &.nav-default {
+        border-bottom: 1px solid @lightGrey;
+        background-color: @white;
 
+        h1:extend(.navigationBar h1) {
+            color: @highlight;
+        }
+
+        .nav-btn:extend(.navigationBar .nav-btn) {
+            color: @highlight;
+        }
+    }
+
+    &.nav-alt {
+        h1:extend(.navigationBar h1) {
+            color: @white;
+        }
+        .nav-btn:extend(.navigationBar .nav-btn) {
+            color: @white;
+        }
     }
 }

--- a/views/add/index.html
+++ b/views/add/index.html
@@ -1,8 +1,4 @@
-<div class="header">
-    <button class="glyph back" v-on="click: goBack" class="back">&lt;</button>
-    <h1>{{ 'Add a Brick' | i18n }}</h1>
-    <div class="glyph spacer"></div>
-</div>
+<div v-component="navigationBar" class="nav-alt"></div>
 <div class="list-wrapper">
     <ul>
         <li v-repeat="block: blocks">

--- a/views/add/index.js
+++ b/views/add/index.js
@@ -10,6 +10,8 @@ module.exports = view.extend({
     template: require('./index.html'),
     data: {
         // Provide a specific sort order
+	title: 'Add A Brick',
+        back: true,
         app: {},
         blocks: [
             blocks.text,

--- a/views/add/index.less
+++ b/views/add/index.less
@@ -18,47 +18,6 @@
         justify-content: center;
     }
 
-    .header {
-        position: fixed;
-        top: 0;
-        width: 100%;
-        display: flex;
-        align-items: center;
-
-        h1 {
-            color: #fff;
-            font-size: 1.1em;
-            font-weight: 400;
-            text-align: center;
-            flex-grow: 1;
-        }
-
-        .back {
-            border: none;
-            background: none;
-            outline: none;
-            text-decoration: none;
-            cursor: pointer;
-            flex-grow: 1;
-        }
-
-        .glyph {
-            font-size: 1.4em;
-            color: #fff;
-            padding: 0px 20px;
-        }
-
-        .spacer {
-            flex-grow: 1;
-            visibility: hidden;
-
-            &:before {
-                content: '<';
-            }
-        }
-
-    }
-
     ul {
         display: block;
         position: relative;

--- a/views/block/index.html
+++ b/views/block/index.html
@@ -1,9 +1,13 @@
-<nav id="navigationBar">
-    <a href="{{back}}" class="nav-btn">{{ 'Cancel' | i18n}}</a>
+<nav id="navigationBar" class="nav-default">
+    <div>
+      <a href="{{back}}" class="nav-btn">{{ 'Cancel' | i18n}}</a>
+    </div>
     <h1>{{title | i18n}}</h1>
-    <button v-class="disabled: saveDisabled" class="save-btn" v-on="click: onSave">
-        <span class="fa fa-check"></span> {{ 'Save' | i18n}}
-    </a>
+    <div>
+      <button v-class="disabled: saveDisabled" class="save-btn" v-on="click: onSave">
+          <span class="fa fa-check"></span> {{ 'Save' | i18n}}
+      </button>
+    </div>
 </nav>
 <form id="attributes">
     <div class="form-group" v-repeat="block.attributes" v-component="{{ getEditor(type) }}"></div>

--- a/views/detail/index.html
+++ b/views/detail/index.html
@@ -1,4 +1,4 @@
-<div v-component="navigationBar"></div>
+<nav v-component="navigationBar" class="nav-default"></nav>
 <div v-if="!app.id" v-component="alert" type="error" message="errorAppNotFound"></div>
 <div v-if="app.id">
     <header>

--- a/views/discover/index.html
+++ b/views/discover/index.html
@@ -1,4 +1,4 @@
-<div v-component="navigationBar"></div>
+<nav v-component="navigationBar" class="nav-default"></nav>
 
 <!--
 TODO: Restore this toggle when we have implemented 'nearby' view.

--- a/views/make/index.html
+++ b/views/make/index.html
@@ -1,7 +1,7 @@
 <div v-show="!app.id" v-component="alert" type="error" message="errorAppNotFound"></div>
 <div v-show="app.id">
 
-    <div id="navigationBar">{{ >navigation }}</div>
+    <div id="navigationBar" class="nav-default">{{ >navigation }}</div>
 
     <div v-show="mode === 'settings'">{{ >settings }}</div>
 

--- a/views/make/navigation.html
+++ b/views/make/navigation.html
@@ -1,4 +1,6 @@
-<a class="nav-btn" v-on="click: goBack">{{ 'Done' | i18n}}</a>
+<div>
+    <a class="nav-btn" v-on="click: goBack">{{ 'Done' | i18n}}</a>
+</div>
 
 <h1>
     <span v-if="mode === 'settings'">{{ 'App Name & Icon' | i18n}}</span>
@@ -11,6 +13,8 @@
     </span>
 </h1>
 
-<a v-if="mode !== 'settings' && !offlineUser" class="nav-btn" href="{{onDone}}">
-    {{ 'Publish' | i18n}}
-</a>
+<div>
+    <a v-if="mode !== 'settings' && !offlineUser" class="nav-btn" href="{{onDone}}">
+        {{ 'Publish' | i18n}}
+    </a>
+</div>

--- a/views/profile/index.html
+++ b/views/profile/index.html
@@ -1,4 +1,4 @@
-<div v-component="navigationBar"></div>
+<nav v-component="navigationBar" class="nav-default"></nav>
 
 <!-- <div id="profile-header">
   <div class="profile-avatar" style="background-image: url({{user.avatar}});"></div>

--- a/views/share/index.html
+++ b/views/share/index.html
@@ -1,4 +1,4 @@
-<div v-component="navigationBar"></div>
+<nav v-component="navigationBar" class="nav-default"></nav>
 
 <form>
     <div v-show="error" v-component="alert" type="error" message="{{error}}"></div>

--- a/views/templates/index.html
+++ b/views/templates/index.html
@@ -1,4 +1,4 @@
-<div v-component="navigationBar"></div>
+<nav v-component="navigationBar" class="nav-default"></nav>
 <div class="list-cell template-cell">
     <a href="/template/{{id}}/detail" class="cell" v-repeat="templates" template="true">
         <div class="left">
@@ -15,5 +15,6 @@
         </div>
     </a>
 </div>
+
 
 <div v-component="tabBar"></div>


### PR DESCRIPTION
Some additions to @gvn's fix to issue#662 (https://github.com/mozilla/webmaker-app/pull/662)

- Applied flexbox changes to the navigationBar container and items of all views (including detailed view), which means all the buttons (i.e. back arrow) are aligned and expand porportionally
- Cleaned up some unecessary extra navigationBar CSS in add view

Important: Two style classes are created for the navigationBar (i.e. - nav-default and nav-alt). They must be applied when creating a new view in the navigationBar markup.