### PR TITLE
Fixes #781:  Android 4.2: Image backgrounds don't work as expected

### DIFF
--- a/views/share/index.less
+++ b/views/share/index.less
@@ -17,8 +17,7 @@
         }
     }
     .share-via {
-        background: no-repeat 15px center @white;
-        background-size: 21.5px 21.5px;
+        background: 15px center no-repeat @white;
         padding-left: 34px;
     }
     .share-via-sms {


### PR DESCRIPTION
Goes from
![](https://cloud.githubusercontent.com/assets/1455535/5862184/af11f196-a23d-11e4-9d80-40c61b026761.png)

To
![](http://snaps.akibraun.com/yybkc.png)