### PR TITLE
Fix #803 v-bind-i18n-html

### DIFF
--- a/_docs/localization/README.md
+++ b/_docs/localization/README.md
@@ -57,14 +57,14 @@ Then, we add the strings to [locale/en_US/mobile-appmaker.json](https://github.c
 
 ## Custom localization directive
 
-Along with the [built-in](http://vuejs.org/api/directives.html) Vue directives is a custom `v-bind-html` directive that is defined in `lib/i18n.js`.
+Along with the [built-in](http://vuejs.org/api/directives.html) Vue directives is a custom `v-bind-i18n-html` directive that is defined in `lib/i18n.js`.
 
-We can see an example of `v-bind-html` in `views/sign-in/index.html`:
+We can see an example of `v-bind-i18n-html` in `views/sign-in/index.html`:
 
 ```html
-<h1><span v-bind-html="'Make and share the web'"></span></h1>
+<h1><span v-bind-i18n-html="'Make and share the web'"></span></h1>
 ```
 
-Here the `v-bind-html` directive will automatically pass the HTML string of "Make and share the web" as the key through the `i18n` filter, which will provide the correct localized content.
+Here the `v-i18n-bind-html` directive will automatically pass the HTML string of "Make and share the web" as the key through the `i18n` filter, which will provide the correct localized content.
 
-Whereas using the `{{ }}` syntax allows you to escape HTML, using `v-bind-html` doesn't escape HTML.
+Whereas using the `{{ }}` syntax allows you to escape HTML, using `v-bind-i18n-html` doesn't escape HTML.

--- a/_docs/localization/README.md
+++ b/_docs/localization/README.md
@@ -65,6 +65,6 @@ We can see an example of `v-bind-i18n-html` in `views/sign-in/index.html`:
 <h1><span v-bind-i18n-html="'Make and share the web'"></span></h1>
 ```
 
-Here the `v-i18n-bind-html` directive will automatically pass the HTML string of "Make and share the web" as the key through the `i18n` filter, which will provide the correct localized content.
+Here the `v-bind-i18n-html` directive will automatically pass the HTML string of "Make and share the web" as the key through the `i18n` filter, which will provide the correct localized content.
 
 Whereas using the `{{ }}` syntax allows you to escape HTML, using `v-bind-i18n-html` doesn't escape HTML.

--- a/components/alert/index.html
+++ b/components/alert/index.html
@@ -2,5 +2,5 @@
     <div class="alert-icon">
         <span class="fa {{icon}}"></span>
     </div>
-    <div v-bind-html="message || 'errorDefault'"></div>
+    <div v-bind-i18n-html="message || 'errorDefault'"></div>
 </div>

--- a/components/appCell/index.html
+++ b/components/appCell/index.html
@@ -4,7 +4,7 @@
     href="{{constructedURL}}">
     <div class="left">
         <span class="title">{{app.name}}</span>
-        <span v-if="app.author" class="description" v-bind-html="'by _'" v-with="{name: app.author.username || app.guestKey}"></span>
+        <span v-if="app.author" class="description" v-bind-i18n-html="'by _'" v-with="{name: app.author.username || app.guestKey}"></span>
     </div>
     <div class="right">
         <div class="app-icon" style="background:{{app.iconColor}};">

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -32,7 +32,7 @@ function Localize () {
         // Bind directives/filters
         if (vue) {
             vue.filter('i18n', self.i18nFilter);
-            vue.directive('bind-html', self.bindHtml);
+            vue.directive('bind-i18n-html', self.bindHtml);
         }
     };
 

--- a/views/detail/index.html
+++ b/views/detail/index.html
@@ -7,7 +7,7 @@
         </div>
         <hgroup>
             <h3>{{app.name}}</h3>
-            <p class="text-light" v-bind-html="'by _'" v-with="name: app.author.username"></p>
+            <p class="text-light" v-bind-i18n-html="'by _'" v-with="name: app.author.username"></p>
         </hgroup>
     </header>
     <ul id="detail-share" v-if="!isTemplate">

--- a/views/profile/index.html
+++ b/views/profile/index.html
@@ -8,7 +8,7 @@
 <div class="profile-details">
 
    <!--  <form class="profile-inputs">
-        <div v-if="!editing" v-bind-html="'name from location'"></div>
+        <div v-if="!editing" v-bind-i18n-html="'name from location'"></div>
         <div v-if="editing" style="height: 100%;">
             <input name="name" placeholder="{{ 'Your name' | i18n }}" type="text" v-model="name">
             <input name="location" placeholder="{{ 'Your location' | i18n }}" type="text" v-model="location">

--- a/views/sign-in/index.html
+++ b/views/sign-in/index.html
@@ -1,5 +1,5 @@
 <div class="top">
-    <h1><span v-bind-html="'Make and share the web'"></span></h1>
+    <h1><span v-bind-i18n-html="'Make and share the web'"></span></h1>
 
 </div>
 


### PR DESCRIPTION
Update `v-bind-html` directive and documentation to be `v-bind-i18n-html`. The goal is to help make it easier to understanding that it passes the contents through the `i18n` filter. 