### PR TITLE
Fixes #900:  Development server can't be accessed from local network

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,6 +72,7 @@ gulp.task('watch', ['build'], function () {
 gulp.task('dev', ['watch'], function() {
   return gulp.src('build')
     .pipe(webserver({
+        host: '0.0.0.0',
         port: 8080,
         livereload: false,
         fallback: 'index.html'


### PR DESCRIPTION
I should note that localhost:8080 will still work. Just now [your local IP]:8080 will as well.