### PR TITLE
color picker always  hides on 'back' now

### DIFF
--- a/components/colorPicker/index.js
+++ b/components/colorPicker/index.js
@@ -10,7 +10,8 @@ module.exports = {
             this.show = true;
             this.originalColor = event;
             this.cancelIntercept = this.onCancel.bind(this);
-            document.addEventListener("backbutton", this.cancelIntercept, true);
+            document.addEventListener('backbutton',
+                this.cancelIntercept, true);
         });
     },
     computed: {
@@ -41,7 +42,8 @@ module.exports = {
         onCancel: function (e) {
             e.preventDefault();
             e.stopPropagation();
-            document.removeEventListener("backbutton", this.cancelIntercept, true);
+            document.removeEventListener('backbutton',
+                this.cancelIntercept, true);
             this.selectedColor = this.originalColor;
             this.show = false;
         }

--- a/components/colorPicker/index.js
+++ b/components/colorPicker/index.js
@@ -9,6 +9,8 @@ module.exports = {
         this.$on('openCP', function (event) {
             this.show = true;
             this.originalColor = event;
+            this.cancelIntercept = this.onCancel.bind(this);
+            document.addEventListener("backbutton", this.cancelIntercept, true);
         });
     },
     computed: {
@@ -38,6 +40,8 @@ module.exports = {
         },
         onCancel: function (e) {
             e.preventDefault();
+            e.stopPropagation();
+            document.removeEventListener("backbutton", this.cancelIntercept, true);
             this.selectedColor = this.originalColor;
             this.show = false;
         }


### PR DESCRIPTION
Fixes #997, fixes #707, by intercepting the hardware back button (android, etc) using phonegaps "backbutton" event handler.