### PR TITLE
Fixes #1009: Previews should not be interactive

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -20,6 +20,11 @@ module.exports = Vue.extend({
     data: {},
     methods: {
         model: require('./model')(),
-        page: require('page')
+        page: require('page'),
+        disableBlocks: function (e) {
+            e.stopPropagation();
+            e.preventDefault();
+            return false;
+        }
     }
 });

--- a/views/detail/index.html
+++ b/views/detail/index.html
@@ -19,17 +19,16 @@
 
         <article class="app-details">
             <div v-show="isAdmin">
-                <!-- TODO do these links need "prefix"/"suffix"? Should the /make/:id/detail be rerouted? -->
-                <a class="btn action" href="/make/{{id}}?mode=edit">Open my app</a>
+                <a class="btn action" href="/make/{{id}}/">Open my app</a>
             </div>
             <div v-show="!isAdmin" class="preview-buttons">
-                <!-- TODO change mode for "remix" usecase -->
                 <a class="btn action" v-on="click: onRemix">Remix App</a>
                 <a class="btn action" href="/make/{{id}}?mode=play">Open App</a>
             </div>
 
             <div class="app-preview">
                 <ul class="blocks">
+                    <li class="preview-overlay" v-on="click: disableBlocks"></li>
                     <li v-component="{{type}}" v-repeat="app.blocks"></li>
                 </ul>
             </div>

--- a/views/make/index.less
+++ b/views/make/index.less
@@ -132,6 +132,17 @@
 
 .blocks {
     .list-reset;
+    position: relative;
+
+    li.preview-overlay {
+        background: transparent;
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 9;
+    }
 
     // TODO - take this out? (li turned into div)
     > li {

--- a/views/template-preview/index.html
+++ b/views/template-preview/index.html
@@ -6,6 +6,7 @@
     </div>
     <div class="app-preview">
         <ul class="blocks">
+            <li class="preview-overlay" v-on="click: disableBlocks"></li>
             <li v-component="{{type}}" v-repeat="app.blocks"></li>
         </ul>
     </div>


### PR DESCRIPTION
The `disableBlocks` function is *probably* not necessary, but I'm not taking any chances with such a multitude of clients.