### PR TITLE
Campus safety (and general phone button edit view) fix

### DIFF
--- a/blocks/phone/index.js
+++ b/blocks/phone/index.js
@@ -10,7 +10,7 @@ module.exports = {
                 type: 'string',
                 value: '+18005555555'
             },
-            innerHTML: {
+            label: {
                 label: 'Label',
                 type: 'string',
                 value: 'Place call'

--- a/lib/templates.json
+++ b/lib/templates.json
@@ -896,7 +896,7 @@
                         "type": "string",
                         "value": "+18005555555"
                     },
-                    "innerHTML": {
+                    "label": {
                         "label": "Label",
                         "type": "string",
                         "value": "Call Campus Safety"

--- a/lib/templates.json
+++ b/lib/templates.json
@@ -647,7 +647,7 @@
     },
     {
         "attributes": {
-            "innerHTML": {
+            "label": {
                 "label": "Label",
                 "type": "string",
                 "value": "Call Band Manager"


### PR DESCRIPTION
Fixes #976 - The phone button used a property called `innerHTML` with the template using `label`. Conflicts arose. This should pacify said conflicts.