### PR TITLE
... better phone fix

### DIFF
--- a/blocks/phone/index.html
+++ b/blocks/phone/index.html
@@ -1,1 +1,1 @@
-<button v-on="click: onClick">{{ attributes.label.value }}</button>
+<button v-on="click: onClick">{{ attributes.innerHTML.value }}</button>

--- a/blocks/phone/index.js
+++ b/blocks/phone/index.js
@@ -10,7 +10,7 @@ module.exports = {
                 type: 'string',
                 value: '+18005555555'
             },
-            label: {
+            innerHTML: {
                 label: 'Label',
                 type: 'string',
                 value: 'Place call'

--- a/lib/templates.json
+++ b/lib/templates.json
@@ -647,7 +647,7 @@
     },
     {
         "attributes": {
-            "label": {
+            "innerHTML": {
                 "label": "Label",
                 "type": "string",
                 "value": "Call Band Manager"
@@ -896,7 +896,7 @@
                         "type": "string",
                         "value": "+18005555555"
                     },
-                    "label": {
+                    "innerHTML": {
                         "label": "Label",
                         "type": "string",
                         "value": "Call Campus Safety"


### PR DESCRIPTION
fixes #1048 - turns out the `innerHTML` propery is shared by so many things that changing it to `label` just for the phone brick, in #1040, created way more problems than it solved.