### PR TITLE
Fixes #1060:  "+" sign on add new block is misplaced

### DIFF
--- a/components/navigationBar/index.less
+++ b/components/navigationBar/index.less
@@ -29,13 +29,15 @@
     .edit-app-name {
         display: flex;
         justify-content: space-between;
-        p {
-            margin-top: 18px;
-        }
+    }
+
+    p {
+        margin: 3px 0 0;
     }
 
     .hide-text-overflow {
         flex-grow: 1;
+        margin: 0;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;


### PR DESCRIPTION
Now the plus button doesn't get bumped to the side when the screen is really small or an app name is really long!
![screen shot 2015-02-12 at 14 05 31](https://cloud.githubusercontent.com/assets/782056/6178039/454017be-b2c0-11e4-8c5c-960bbfa79ea6.png)
![screen shot 2015-02-12 at 14 06 11](https://cloud.githubusercontent.com/assets/782056/6178046/5021c182-b2c0-11e4-93f0-ec02addc0186.png)
