### PR TITLE
changes how to deal with unknown strings

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -64,7 +64,10 @@ function Localize () {
         var dict = self.dictionary[key];
         var defaultLang = self.dictionaries[self.defaultLang][key];
         if (self.dictionaries[self.locale] !== undefined) {
-            return self.dictionaries[self.locale][key];
+            var localized = self.dictionaries[self.locale][key];
+            if (!!localized) {
+                return localized;
+            }
         }
         return dict || defaultLang || key;
     };


### PR DESCRIPTION
fixes #1070, the original fix was missing a check to see whether or not the to-resolve string actually led to a translation. This patch updates that code path to only return if a translation is found, otherwise it falls through to the fallback code