### PR TITLE
Fixes #1079:  icons in the inline editor are too small

### DIFF
--- a/components/inlineEditor/index.less
+++ b/components/inlineEditor/index.less
@@ -66,6 +66,7 @@
             border-right: 1px solid #1A98B8;
             border-bottom: 1px solid #1A98B8;
             color: @white;
+            font-size: 26px;
 
             &:active {
                 background: #32B2D2;

--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -8,7 +8,7 @@
     padding-bottom: 12px;
     font-family: 'Fira Sans', sans-serif;
     font-size: 14px;
-    font-weight: 400;  
+    font-weight: 400;
     color: white;
     line-height: 1;
     border-radius: 4px;
@@ -24,8 +24,6 @@
         border: 0;
         border-radius: 0;
         flex-grow: 1;
-        padding-top: 1em;
-        padding-bottom: 1em;
         box-shadow: none;
 
         &:active {


### PR DESCRIPTION
From #1079, icons about double the size:
![screen shot 2015-02-13 at 12 47 51](https://cloud.githubusercontent.com/assets/782056/6195010/c73c8fd6-b37e-11e4-8159-d6ee02c8f018.png)
