### PR TITLE
Fixes #1097: Text block editor has a resize handle

### DIFF
--- a/components/block-editors/string/index.html
+++ b/components/block-editors/string/index.html
@@ -1,3 +1,3 @@
 <label for="{{id}}">{{ label | i18n }}</label>
-<textarea name="{{id}}" type="text" v-model="value" placeholder="{{ 'Text' | i18n }}"></textarea>
+<div contenteditable="true" name="{{id}}" type="text" v-model="value" placeholder="{{ 'Text' | i18n }}"></div>
 <div v-show="!value" class="form-error">{{ 'errorNoText' | i18n }}</div>

--- a/components/block-editors/string/index.less
+++ b/components/block-editors/string/index.less
@@ -1,0 +1,20 @@
+[contenteditable=true] {
+    background: @white;
+    color: @darkGrey;
+    padding: 8px 10px;
+    box-shadow: none;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: 400;
+    background: none repeat scroll 0 0 @white;
+    border: 1px solid @lightGrey;
+    text-decoration: none;
+    &:empty:before {
+        content: attr(placeholder);
+        display: block;
+    }
+    &:focus {
+        outline: medium none;
+        border-color: #64A8EE;
+    }
+}


### PR DESCRIPTION
Should solve #1097. Didn't require any additional javascript to work, either. Yay!