### PR TITLE
[WIP] Fixes #1078: Moving bricks in inline editor

### DIFF
--- a/components/inlineEditor/index.js
+++ b/components/inlineEditor/index.js
@@ -112,7 +112,7 @@ module.exports = {
         move: function (steps) {
             var self = this;
 
-            self.stopEditing();
+            //self.stopEditing();
 
             // Delay about half the time the shim takes to fade out
             // Delay is also necessary for blockList to measure heights properly


### PR DESCRIPTION
This PR will ultimately fix #1078, but is currently WIP because of the `TypeError: obj is undefined` error Vue.js is throwing right now makes it hard to confirm that it works.