### PR TITLE
Fix lint errors in analytics library

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -5,7 +5,7 @@
  * @author  Adam Lofting <adam@mozillafoundation.org>
  */
 
-var xhr = require("xhr");
+var xhr = require('xhr');
 var localForage = require('localforage');
 var clone = require('clone');
 
@@ -132,14 +132,14 @@ function getCommonAppValues () {
     commonAppValues = {
         // Required
         v: 1,                               // MP Version
-        tid : config.GA_TRACKING_ID,        // Tracking ID / Property ID.
-        cid : model.data.session.guestId,   // Anonymous Client ID.
+        tid: config.GA_TRACKING_ID,        // Tracking ID / Property ID.
+        cid: model.data.session.guestId,   // Anonymous Client ID.
 
         // Additional values we want to use for App Specific measurement
-        an : packageJSON.name,              // Application Name
-        //aid : '',                         // Application ID
-        av : packageJSON.version,           // Application Version
-        //aiid : '',                        // Application Installer ID
+        an: packageJSON.name,              // Application Name
+        //aid: '',                         // Application ID
+        av: packageJSON.version,           // Application Version
+        //aiid: '',                        // Application Installer ID
         ds: 'app',                          // Data Source
         ul: model.data.session.locale.toLowerCase(),     // User Language
         ua: navigator.userAgent             // User Agent
@@ -181,8 +181,8 @@ function attemptSendToGA (hit, callback) {
     // Make a POST request to GA
     xhr({
         body: gaBody,
-        uri: "https://ssl.google-analytics.com/collect",
-        method: "POST"
+        uri: 'https://ssl.google-analytics.com/collect',
+        method: 'POST'
     }, function (err, resp, body) {
         if (resp.statusCode === 200) {
             // we're got as far as GA (and must be online)


### PR DESCRIPTION
Will explore apparent race condition in the test suite separately. This should resolve the intermittent `lint` failures.