### PR TITLE
bring template.json in line with the updated phone brick

### DIFF
--- a/lib/templates.json
+++ b/lib/templates.json
@@ -651,6 +651,12 @@
                 "label": "Phone #",
                 "type": "string",
                 "value": "+18005555555"
+            },
+            "color": {
+                "label": "Button Color",
+                "type": "color",
+                "value": "#64A8EE",
+                "skipAutoRender": true
             }
         },
         "type": "phone"
@@ -893,6 +899,12 @@
                         "label": "Label",
                         "type": "string",
                         "value": "Call Campus Safety"
+                    },
+                    "color": {
+                        "label": "Button Color",
+                        "type": "color",
+                        "value": "#64A8EE",
+                        "skipAutoRender": true
                     }
                 }
             },


### PR DESCRIPTION
fixes #1189 by making sure the template.json file has the same properties as the updated phone brick does now (`innerHTML`, `number`, and the missing-before-now `color`)