### PR TITLE
Remove old locale files

### DIFF
--- a/gulp/download-locales.js
+++ b/gulp/download-locales.js
@@ -1,13 +1,23 @@
 var downloadLocales = require('webmaker-download-locales');
+var glob = require('glob');
+var fs = require('fs-extra');
 
 // Which languages should we pull down?
 // Don't include en-US because that's committed into git already
 var supportedLanguages = ['id', 'en_CA', 'es_CL', 'fr', 'nl', 'es_MX', 'cs', 'sv', 'bn_BD'];
 
 module.exports = function (callback) {
-    downloadLocales({
-        app: 'webmaker-app',
-        dir: 'locale',
-        languages: supportedLanguages
-    }, callback);
+
+    glob('!./locale/!(en_US)/**.json', function (err, files) {
+        files.forEach(function (file) {
+            fs.removeSync(file);
+        });
+        downloadLocales({
+            app: 'webmaker-app',
+            dir: 'locale',
+            languages: supportedLanguages
+        }, function (err) {
+            console.log('foo');
+        });
+    });
 };

--- a/gulp/download-locales.js
+++ b/gulp/download-locales.js
@@ -16,8 +16,6 @@ module.exports = function (callback) {
             app: 'webmaker-app',
             dir: 'locale',
             languages: supportedLanguages
-        }, function (err) {
-            console.log('foo');
-        });
+        }, callback);
     });
 };


### PR DESCRIPTION
This removes old locale files before downloading new ones, so we don't accidentally use old files that no longer exist.