### PR TITLE
moves the onClick handler to a "methods" block

### DIFF
--- a/blocks/phone/index.js
+++ b/blocks/phone/index.js
@@ -23,13 +23,10 @@ module.exports = {
             }
         }
     },
-    created: function () {
-        var self = this;
-
-        // Disable if editing mode
-        self.$data.onClick = function (e) {
+    methods: {
+        onClick: function (e) {
             e.preventDefault();
-            window.location = 'tel:' + self.$data.attributes.number.value;
-        };
+            window.location = 'tel:' + this.$data.attributes.number.value;
+        }
     }
 };


### PR DESCRIPTION
fixes #1269 by moving the onClick handler into the Vue object's prototype (using the `methods` block), so that it doesn't get lost across clone() operations