### PR TITLE
proper onclick handling for SMS brick

### DIFF
--- a/blocks/sms/index.html
+++ b/blocks/sms/index.html
@@ -1,1 +1,1 @@
-<button style="background-color: {{attributes.color.value}}"></button>
+<button v-on="click: onClick" style="background-color: {{attributes.color.value}}"></button>

--- a/blocks/sms/index.js
+++ b/blocks/sms/index.js
@@ -28,14 +28,13 @@ module.exports = {
             }
         }
     },
-    ready: function () {
-        var self = this;
-        self.$el.addEventListener('click', function (e) {
+    methods: {
+        onClick: function (e) {
             e.preventDefault();
-
-            var number = self.$data.attributes.value.value;
-            var body = self.$data.attributes.messageBody.value;
+            var attr = this.$data.attributes;
+            var number = attr.value.value;
+            var body = attr.messageBody.value;
             window.location = 'sms:' + number + '?body=' + body;
-        });
+        }
     }
 };


### PR DESCRIPTION
fixes #1270 by appying the same fix that was used for #1269, setting the onClick behaviour as a `methods` prototype property, and handing clicks with Vue's `v-on`.

Also relies on https://github.com/mozilla/webmaker-app-cordova/pull/39 landing in webmaker-app-cordova, which enables launching external SMS handling.