### PR TITLE
2 steps back after adding new block

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -5,9 +5,12 @@ var UA = require('./ua');
 var analytics = require('./analytics');
 var fastclick;
 
+window.urlHistory = [];
+
 module.exports = function (app) {
     // Track history for session restoration
     page(function (ctx, next) {
+        window.urlHistory.push(ctx.path);
         if (!model._ready) return next();
         model.data.session.path = ctx.path;
         if (!UA.isFirefoxOS) {

--- a/views/add/index.js
+++ b/views/add/index.js
@@ -72,7 +72,7 @@ module.exports = view.extend({
             // Add to model & redirect to block edit page.
             // Newly added block always in index 0.
             if (blockId === 'image') {
-                self.page('/make/' + id);
+                global.history.back();
             } else {
                 self.page('/make/' + id + '/block/0');
             }

--- a/views/block/index.js
+++ b/views/block/index.js
@@ -57,6 +57,12 @@ module.exports = view.extend({
                 attributes: this.$data.block.attributes
             });
             this.$data.saveDisabled = true;
+
+            // Go back an extra step after adding a new block
+            if (window.urlHistory[window.urlHistory.length - 2].match(/\/add$/)) {
+                global.history.back();
+            }
+
             global.history.back();
             global.history.replaceState({}, '', this.$data.back);
         },

--- a/views/block/index.js
+++ b/views/block/index.js
@@ -69,12 +69,13 @@ module.exports = view.extend({
         onCancel: function (e) {
             e.preventDefault();
             if (this.$data.mode === "edit") {
-                this.page(this.$data.back);
+                global.history.back();
+                global.history.replaceState({}, '', this.$data.back);
                 return;
             }
             app.remove(index);
             var id = this.$root.$data.params.id;
-            this.page('/make/' + id + '/add');
+            global.history.back();
         }
     },
     created: function () {


### PR DESCRIPTION
Right now after you add a block you'll go back to the choose a block screen. This should prevent that.

I know it's kind of gross, but it's a band aid until we can rewrite navigation... :ambulance: 