### PR TITLE
Android docs #1382

### DIFF
--- a/_docs/get_started/android.md
+++ b/_docs/get_started/android.md
@@ -97,7 +97,6 @@ Finally, `cd` back to `webmaker-app-cordova/` and run `npm run android` to rebui
 
 To run the Android SDK Manager with the `android` command you'll need to have the Java Development Kit (JDK) installed. You can download the JDK [here](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
 
-
 ### Android WebView Browser
 
 You may also want to download [WebView Developer Browser](https://play.google.com/store/apps/details?id=com.webviewbrowser&hl=en) from the Google Play store so that you can quickly run the web version of webmaker-app. This is the browser Cordova uses on Android 4.2.

--- a/_docs/get_started/android.md
+++ b/_docs/get_started/android.md
@@ -38,7 +38,7 @@ If you see something like `Android Debug Bridge version 1.0.32` you have adb ins
 - to be able to make changes in this app and be able to build a new version in Cordova, **you will also need to run `npm link`** in the root of this directory
 
 ## Set up the Cordova Wrapper
-- clone `mozilla/webmaker-app-cordova`
+- clone [mozilla/webmaker-app-cordova](https://github.com/mozilla/webmaker-app-cordova)
 - `npm install`
 - `npm start`
 
@@ -92,6 +92,11 @@ Finally, `cd` back to `webmaker-app-cordova/` and run `npm run android` to rebui
 
 
 ## Other tips
+
+### Running Android SDK Manager
+
+To run the Android SDK Manager with the `android` command you'll need to have the Java Development Kit (JDK) installed. You can download the JDK [here](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
+
 
 ### Android WebView Browser
 


### PR DESCRIPTION
* Add Cordova repo link

* Clarify JDK dependency 

Without the Java Development Kit installed users won't be able to run the android sdk manager.