### PR TITLE
refactor the App object to a normal object instead of inline-defined object

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,0 +1,112 @@
+var clone = require('clone');
+
+function App(appref, id, fbRef, data, _firebase, _newBlock) {
+  this.appref = appref;
+  this.id = id;
+  this.data = data || null;
+  this.firebase = fbRef || _firebase.child(id);
+  this.firebase.on('value', this.broadcast, this);
+  this.newBlock = _newBlock;
+}
+
+App.prototype = {
+  broadcast: function (snapshot) {
+    this.data = this.appref.processSnapshot(snapshot);
+    this.appref._vm.$broadcast(snapshot.key(), this.data);
+  },
+
+  update: function (properties) {
+    properties = JSON.parse(JSON.stringify(properties));
+    this.firebase.update(properties, this.appref._onSync);
+  },
+
+  updateBlock: function (id, properties) {
+    properties = JSON.parse(JSON.stringify(properties));
+    this.firebase.child('blocks/' + id).update(properties, this.appref._onSync);
+  },
+
+  insert: function (type) {
+    var block = this.newBlock(type);
+    if (!block) {
+      console.error('Block type ' + type + ' not found.');
+      return;
+    }
+    var ref = this.firebase.child('blocks');
+    ref.once('value', function (snapshot) {
+      var blocks = snapshot.val() || [];
+      blocks.unshift(block);
+      ref.set(blocks);
+    });
+  },
+
+  remove: function (blockIndex) {
+    var ref = this.firebase.child('blocks');
+
+    var msg = 'Block with index ' + blockIndex + ' does not exist.';
+    ref.once('value', function (snapshot) {
+      var blocks = snapshot.val();
+      if (!blocks[blockIndex]) {
+        console.error(msg);
+        return;
+      }
+      blocks.splice(blockIndex, 1);
+      ref.set(blocks, this.appref._onSync);
+    });
+  },
+
+  duplicate: function (blockIndex) {
+    var ref = this.firebase.child('blocks');
+
+    var msg = 'Block with index ' + blockIndex + ' does not exist.';
+    ref.once('value', function (snapshot) {
+      var blocks = snapshot.val();
+      if (!blocks[blockIndex]) {
+        console.error(msg);
+        return;
+      }
+
+      blocks.splice(blockIndex, 0, clone(blocks[blockIndex]));
+      ref.set(blocks, this.appref._onSync);
+    });
+  },
+
+  move: function (blockIndex, steps) {
+    var ref = this.firebase.child('blocks');
+
+    ref.once('value', function (snapshot) {
+      var blocks = snapshot.val();
+
+      if (blockIndex + steps < 0) {
+        console.error('Can\'t move block to negative position');
+        return;
+      }
+
+      if (blockIndex + steps > blocks.length - 1) {
+        console.error('Block is already at the end of the list');
+        return;
+      }
+
+      if (!blocks[blockIndex]) {
+        console.error('Block ' + blockIndex + ' doesn\'t exist.');
+        return;
+      }
+
+      var blockToMove = blocks[blockIndex];
+
+      // remove block from array
+      blocks.splice(blockIndex, 1);
+
+      // Put block in new array position
+      blocks.splice(blockIndex + steps, 0, blockToMove);
+
+      ref.set(blocks, this.appref._onSync);
+    });
+  },
+
+  removeApp: function () {
+    this.firebase.remove(this.appref._onSync);
+    this.appref._removeAppRef(this.id);
+  }
+};
+
+module.exports = App;

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -5,6 +5,7 @@ var config = require('../config');
 var utils = require('./utils');
 var i18n = require('./i18n');
 var templates = require('./templates.json');
+var App = require('./app');
 var model = require('./model')();
 var Blocks = require('./blocks');
 var blocks = new Blocks();
@@ -32,7 +33,7 @@ Store.prototype._onSync = function _onSync(err) {
   this._vm.showAlert('Oops! We\'re having trouble syncing your data');
 };
 
-Store.prototype._processSnapshot = function _processSnapshot(snapshot) {
+Store.prototype.processSnapshot = function processSnapshot(snapshot) {
   var res = snapshot.val();
   if (!res) {
     return null;
@@ -46,9 +47,7 @@ Store.prototype._createAppRef = function (id, fbRef, data) {
     this._removeAppRef(id);
   }
 
-  var process = this._processSnapshot;
-
-  function newBlock(blockId) {
+  var app = new App(this, id, fbRef, data, _firebase, function newBlock(blockId) {
     var block = blocks[blockId];
     if (!block) {
       return;
@@ -59,116 +58,8 @@ Store.prototype._createAppRef = function (id, fbRef, data) {
         i18n.get(clonedBlock.attributes.innerHTML.value);
     }
     return clonedBlock;
-  }
+  });
 
-  function App(appref) {
-    this.appref = appref;
-    this.id = id;
-    this.data = data || null;
-    this.firebase = fbRef || _firebase.child(id);
-
-    var broadcast = function (snapshot) {
-      this.data = process(snapshot);
-      this.appref._vm.$broadcast(snapshot.key(), data);
-    }.bind(this);
-
-    this.firebase.on('value', broadcast);
-  }
-
-  App.prototype.update = function (properties) {
-    properties = JSON.parse(JSON.stringify(properties));
-    this.firebase.update(properties, this.appref._onSync);
-  };
-
-  App.prototype.updateBlock = function (id, properties) {
-    properties = JSON.parse(JSON.stringify(properties));
-    this.firebase.child('blocks/' + id).update(properties, this.appref._onSync);
-  };
-
-  App.prototype.insert = function (type) {
-    var block = newBlock(type);
-    if (!block) {
-      console.error('Block type ' + type + ' not found.');
-      return;
-    }
-    var ref = this.firebase.child('blocks');
-    ref.once('value', function (snapshot) {
-      var blocks = snapshot.val() || [];
-      blocks.unshift(block);
-      ref.set(blocks);
-    });
-  };
-
-  App.prototype.remove = function (blockIndex) {
-    var ref = this.firebase.child('blocks');
-
-    var msg = 'Block with index ' + blockIndex + ' does not exist.';
-    ref.once('value', function (snapshot) {
-      var blocks = snapshot.val();
-      if (!blocks[blockIndex]) {
-        console.error(msg);
-        return;
-      }
-      blocks.splice(blockIndex, 1);
-      ref.set(blocks, this.appref._onSync);
-    });
-  };
-
-  App.prototype.duplicate = function (blockIndex) {
-    var ref = this.firebase.child('blocks');
-
-    var msg = 'Block with index ' + blockIndex + ' does not exist.';
-    ref.once('value', function (snapshot) {
-      var blocks = snapshot.val();
-      if (!blocks[blockIndex]) {
-        console.error(msg);
-        return;
-      }
-
-      blocks.splice(blockIndex, 0, clone(blocks[blockIndex]));
-      ref.set(blocks, this.appref._onSync);
-    });
-  };
-
-  App.prototype.move = function (blockIndex, steps) {
-    var ref = this.firebase.child('blocks');
-
-    ref.once('value', function (snapshot) {
-      var blocks = snapshot.val();
-
-      if (blockIndex + steps < 0) {
-        console.error('Can\'t move block to negative position');
-        return;
-      }
-
-      if (blockIndex + steps > blocks.length - 1) {
-        console.error('Block is already at the end of the list');
-        return;
-      }
-
-      if (!blocks[blockIndex]) {
-        console.error('Block ' + blockIndex + ' doesn\'t exist.');
-        return;
-      }
-
-      var blockToMove = blocks[blockIndex];
-
-      // remove block from array
-      blocks.splice(blockIndex, 1);
-
-      // Put block in new array position
-      blocks.splice(blockIndex + steps, 0, blockToMove);
-
-      ref.set(blocks, this.appref._onSync);
-    });
-  };
-
-  App.prototype.removeApp = function () {
-    this.firebase.remove(this.appref._onSync);
-    this.appref._removeAppRef(id);
-  };
-
-  var app = new App(this);
   _appRefs[id] = app;
 
   return app;
@@ -190,7 +81,7 @@ Store.prototype.setQuery = function setQuery(userId) {
   }
 
   var self = this;
-  var process = self._processSnapshot;
+  var process = self.processSnapshot;
 
   if (_queryRef) {
     self.unsetQuery();

--- a/test/unit/storage.js
+++ b/test/unit/storage.js
@@ -89,17 +89,17 @@ describe('Storage', function () {
             assert.equal(typeof storage._log, 'function');
         });
     });
-    describe('#_processSnapshot', function () {
+    describe('#processSnapshot', function () {
         it('should be a function', function () {
-            assert.equal(typeof storage._processSnapshot, 'function');
+            assert.equal(typeof storage.processSnapshot, 'function');
         });
         it('should return a data object given a Fb snapshot', function () {
             var snapshot = {
                 key: function () { return '123'; },
                 val: function() { return { name: 'Hello world' }; }
             };
-            var result = storage._processSnapshot(snapshot)
-            assert.equal(typeof storage._processSnapshot, 'function');
+            var result = storage.processSnapshot(snapshot)
+            assert.equal(typeof storage.processSnapshot, 'function');
             assert.equal(result.id, 123);
             assert.equal(result.name, 'Hello world');
         });


### PR DESCRIPTION
fixes #1425 by moving the `App` object definition into its own require-able file, rather than inlining the definition to be redeclared when `Storage` functions are called.

This passes lint/jscs/beautify + unit tests, but it also seems like the kind of refactor that is going to reveal bits that we didn't have test coverage for, so this will need some `RealHuman™` testing before we land it.