### PR TITLE
Integrate node/npm and `npm run build` into gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-buildscript () {
+buildscript {
     repositories {
         jcenter()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-buildscript {
+buildscript () {
     repositories {
         jcenter()
     }
@@ -12,8 +12,23 @@ buildscript {
     }
 }
 
+plugins {
+  id 'com.moowork.node' version '0.9'
+}
+
+node {
+    version = '0.12.2'
+    npmVersion = '2.7.4'
+    distBaseUrl = 'http://nodejs.org/dist'
+    download = true
+}
+
 allprojects {
     repositories {
         jcenter()
     }
+}
+
+task preBuild (type: NpmTask) {
+    args = ['run', 'build']
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-all.zip

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/k88hudson/webmaker-android.git"
+    "url": "https://github.com/mozilla/webmaker-app.git"
   },
   "author": "",
   "license": "MPL-2.0",
   "bugs": {
-    "url": "https://github.com/k88hudson/webmaker-android/issues"
+    "url": "https://github.com/mozilla/webmaker-app/issues"
   },
-  "homepage": "https://github.com/k88hudson/webmaker-android",
+  "homepage": "https://github.com/mozilla/webmaker-app",
   "devDependencies": {
     "autoless": "^0.1.6",
     "autoprefixer": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "webmaker-app",
-  "version": "0.0.0",
+  "name": "webmaker-android",
+  "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
     "start": "npm run build && npm-run-all --parallel webserver watch:static watch:js watch:css watch:html",
     "build:clean": "rimraf app/src/main/assets/www/ mkdirp app/src/main/assets/www/",
-    "build:static": "mkdirp www_src/static/ ncp www_src/static/ app/src/main/assets/www/",
+    "build:static": "mkdirp www_src/static/ && mkdirp app/src/main/assets/ && ncp www_src/static/ app/src/main/assets/www/",
     "build:js": "webpack",
     "build:css": "npm run watch:css -- --no-watch",
     "build:html": "node ./npm_tasks/build-html",
-    "build": " npm-run-all build:clean build:static build:js build:css",
+    "build": " npm-run-all build:clean build:static build:js build:css build:html",
     "watch:static": "watch \"npm run build:static\" www_src/static",
     "watch:js": "npm run build:js -- -d --watch",
     "watch:css": "autoless --source-map --autoprefix \"last 2 versions\" www_src app/src/main/assets/www",
@@ -19,14 +19,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mozilla/webmaker-app.git"
+    "url": "https://github.com/k88hudson/webmaker-android.git"
   },
   "author": "",
   "license": "MPL-2.0",
   "bugs": {
-    "url": "https://github.com/mozilla/webmaker-app/issues"
+    "url": "https://github.com/k88hudson/webmaker-android/issues"
   },
-  "homepage": "https://github.com/mozilla/webmaker-app",
+  "homepage": "https://github.com/k88hudson/webmaker-android",
   "devDependencies": {
     "autoless": "^0.1.6",
     "autoprefixer": "^5.1.0",


### PR DESCRIPTION
This PR integrates a task called `preBuild` into `build.gradle` that uses the [gradle-node-plugin](https://github.com/srs/gradle-node-plugin) to ensure the proper Node and NPM versions during build. This will help when automating builds via Travis and just generally help us standardize the build environment. Based on original commit from @ryanw-ny