### PR TITLE
removes a nullpointer exception when retriggering oncreate without extras

### DIFF
--- a/app/src/main/java/mozilla/org/webmaker/WebmakerActivity.java
+++ b/app/src/main/java/mozilla/org/webmaker/WebmakerActivity.java
@@ -31,12 +31,15 @@ public class WebmakerActivity extends Activity {
         super.onCreate(savedInstanceState);
 
         // Extract route information from intent extras
-        Bundle intentExtras = getIntent().getExtras();
         routeParams = new JSONObject();
-        try {
-            routeParams.put("project", intentExtras.get("projectId"));
-        } catch (JSONException e) {
-            e.printStackTrace();
+
+        Bundle intentExtras = getIntent().getExtras();
+        if (intentExtras != null) {
+            try {
+                routeParams.put("project", intentExtras.get("projectId"));
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
         }
 
         // Add webview to layout


### PR DESCRIPTION
we missed a potential null pointer, so going from project to page and then back will crash webmaker-app =x